### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/LukeMathWalker/cheadergen/compare/0.2.0...0.2.1) - 2026-05-16
+
+### ⛰️ Features
+
+- Introduce new CLI commands for cache management: cache clear, cache warm and cache show dir (by @LukeMathWalker)
+
+### 🐛 Bug Fixes
+
+- Ensure nightly toolchain version is available in packaging context (by @LukeMathWalker)
+- Don't cache JSON docs for workspace members. Invalidation logic doesn't seem to be as tight as we previously thought, so disable while we investigate further. (by @LukeMathWalker)
+
+### Contributors
+
+- @LukeMathWalker
+
 ## [0.2.0](https://github.com/LukeMathWalker/cheadergen/compare/0.1.4...0.2.0) - 2026-05-12
 
 ### ‼️ Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cheadergen_macros",
  "trybuild",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 edition = "2024"
 repository = "https://github.com/LukeMathWalker/cheadergen"
 license = "Apache-2.0"
-version = "0.2.0"
+version = "0.2.1"
 
 [workspace.lints.clippy]
 # Use `#[expect]` instead of `#[allow]` so we are warned when they become obsolete.
@@ -18,9 +18,9 @@ allow_attributes = "warn"
 private-intra-doc-links = "allow"
 
 [workspace.dependencies]
-cheadergen = { path = "cheadergen", version = "0.2.0" }
-cheadergen_cli = { path = "cheadergen_cli", version = "0.2.0" }
-cheadergen_macros = { path = "cheadergen_macros", version = "0.2.0" }
+cheadergen = { path = "cheadergen", version = "0.2.1" }
+cheadergen_cli = { path = "cheadergen_cli", version = "0.2.1" }
+cheadergen_macros = { path = "cheadergen_macros", version = "0.2.1" }
 rustdoc-types = "0.57.3"
 rustdoc_ext = "0.1.1"
 rustdoc_ir = "0.1.1"


### PR DESCRIPTION



## 🤖 New release

* `cheadergen_macros`: 0.2.0 -> 0.2.1
* `cheadergen`: 0.2.0 -> 0.2.1
* `cheadergen_cli`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `cheadergen`

<blockquote>

## [0.2.1](https://github.com/LukeMathWalker/cheadergen/compare/0.2.0...0.2.1) - 2026-05-16

### ⛰️ Features

- Introduce new CLI commands for cache management: cache clear, cache warm and cache show dir (by @LukeMathWalker)

### 🐛 Bug Fixes

- Ensure nightly toolchain version is available in packaging context (by @LukeMathWalker)
- Don't cache JSON docs for workspace members. Invalidation logic doesn't seem to be as tight as we previously thought, so disable while we investigate further. (by @LukeMathWalker)

### Contributors

- @LukeMathWalker
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).