### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/LukeMathWalker/cheadergen/compare/0.2.1...0.2.2) - 2026-05-18
+
+### 🐛 Bug Fixes
+
+- Ensure that generated floating point constants are inferred as floats by the C compiler. (by @LukeMathWalker)
+
+### Contributors
+
+- @LukeMathWalker
+
 ## [0.2.1](https://github.com/LukeMathWalker/cheadergen/compare/0.2.0...0.2.1) - 2026-05-16
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cheadergen_macros",
  "trybuild",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 edition = "2024"
 repository = "https://github.com/LukeMathWalker/cheadergen"
 license = "Apache-2.0"
-version = "0.2.1"
+version = "0.2.2"
 
 [workspace.lints.clippy]
 # Use `#[expect]` instead of `#[allow]` so we are warned when they become obsolete.
@@ -18,9 +18,9 @@ allow_attributes = "warn"
 private-intra-doc-links = "allow"
 
 [workspace.dependencies]
-cheadergen = { path = "cheadergen", version = "0.2.1" }
-cheadergen_cli = { path = "cheadergen_cli", version = "0.2.1" }
-cheadergen_macros = { path = "cheadergen_macros", version = "0.2.1" }
+cheadergen = { path = "cheadergen", version = "0.2.2" }
+cheadergen_cli = { path = "cheadergen_cli", version = "0.2.2" }
+cheadergen_macros = { path = "cheadergen_macros", version = "0.2.2" }
 rustdoc-types = "0.57.3"
 rustdoc_ext = "0.1.1"
 rustdoc_ir = "0.1.1"


### PR DESCRIPTION



## 🤖 New release

* `cheadergen_macros`: 0.2.1 -> 0.2.2
* `cheadergen`: 0.2.1 -> 0.2.2
* `cheadergen_cli`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `cheadergen`

<blockquote>

## [0.2.2](https://github.com/LukeMathWalker/cheadergen/compare/0.2.1...0.2.2) - 2026-05-18

### 🐛 Bug Fixes

- Ensure that generated floating point constants are inferred as floats by the C compiler. (by @LukeMathWalker)

### Contributors

- @LukeMathWalker
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).