### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/LukeMathWalker/cheadergen/compare/0.2.2...0.2.3) - 2026-05-20
+
+### 🐛 Bug Fixes
+
+- Work around a `guppy` issue which affected workspaces with crates that depend on themselves as dev dependencies. (by @LukeMathWalker)
+
 ## [0.2.2](https://github.com/LukeMathWalker/cheadergen/compare/0.2.1...0.2.2) - 2026-05-18
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cheadergen_macros",
  "trybuild",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 edition = "2024"
 repository = "https://github.com/LukeMathWalker/cheadergen"
 license = "Apache-2.0"
-version = "0.2.2"
+version = "0.2.3"
 
 [workspace.lints.clippy]
 # Use `#[expect]` instead of `#[allow]` so we are warned when they become obsolete.
@@ -18,9 +18,9 @@ allow_attributes = "warn"
 private-intra-doc-links = "allow"
 
 [workspace.dependencies]
-cheadergen = { path = "cheadergen", version = "0.2.2" }
-cheadergen_cli = { path = "cheadergen_cli", version = "0.2.2" }
-cheadergen_macros = { path = "cheadergen_macros", version = "0.2.2" }
+cheadergen = { path = "cheadergen", version = "0.2.3" }
+cheadergen_cli = { path = "cheadergen_cli", version = "0.2.3" }
+cheadergen_macros = { path = "cheadergen_macros", version = "0.2.3" }
 rustdoc-types = "0.57.3"
 rustdoc_ext = "0.1.1"
 rustdoc_ir = "0.1.1"


### PR DESCRIPTION



## 🤖 New release

* `cheadergen_macros`: 0.2.2 -> 0.2.3
* `cheadergen`: 0.2.2 -> 0.2.3
* `cheadergen_cli`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>


## `cheadergen`

<blockquote>

## [0.2.2](https://github.com/LukeMathWalker/cheadergen/compare/0.2.1...0.2.2) - 2026-05-18

### 🐛 Bug Fixes

- Ensure that generated floating point constants are inferred as floats by the C compiler. (by @LukeMathWalker)

### Contributors

- @LukeMathWalker
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).