### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/LukeMathWalker/cheadergen/compare/0.2.4...0.3.0) - 2026-06-11
+
+### ‼️ Breaking changes
+
+- Remove positional path argument. Alignment default behaviour with cargo. (by @LukeMathWalker) - #19
+
+### 🐛 Bug Fixes
+
+- Convert Rust-only char escapes to valid C in generated `#define` values (by @LukeMathWalker) - #20
+
+### 📚 Documentation
+
+- Publish a high-level user guide at <https://cheadergen.com> (by @LukeMathWalker)
+
+### Contributors
+
+- @LukeMathWalker
+
 ## [0.2.4](https://github.com/LukeMathWalker/cheadergen/compare/0.2.3...0.2.4) - 2026-06-04
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "cheadergen_macros",
  "trybuild",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_cli"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 homepage = "https://cheadergen.com"
 repository = "https://github.com/LukeMathWalker/cheadergen"
 license = "Apache-2.0"
-version = "0.2.4"
+version = "0.3.0"
 
 [workspace.lints.clippy]
 # Use `#[expect]` instead of `#[allow]` so we are warned when they become obsolete.
@@ -19,9 +19,9 @@ allow_attributes = "warn"
 private-intra-doc-links = "allow"
 
 [workspace.dependencies]
-cheadergen = { path = "cheadergen", version = "0.2.4" }
-cheadergen_cli = { path = "cheadergen_cli", version = "0.2.4" }
-cheadergen_macros = { path = "cheadergen_macros", version = "0.2.4" }
+cheadergen = { path = "cheadergen", version = "0.3.0" }
+cheadergen_cli = { path = "cheadergen_cli", version = "0.3.0" }
+cheadergen_macros = { path = "cheadergen_macros", version = "0.3.0" }
 rustdoc-types = "0.57.3"
 rustdoc_ext = "0.1.1"
 rustdoc_ir = "0.1.1"

--- a/docs/src/getting-started/install.md
+++ b/docs/src/getting-started/install.md
@@ -12,7 +12,7 @@ On macOS or Linux:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/LukeMathWalker/cheadergen/releases/download/0.2.4/cheadergen_cli-installer.sh \
+  https://github.com/LukeMathWalker/cheadergen/releases/download/0.3.0/cheadergen_cli-installer.sh \
   | sh
 ```
 
@@ -22,7 +22,7 @@ The installer downloads the prebuilt binary for your platform and drops it into
 On Windows, via Powershell:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/LukeMathWalker/cheadergen/releases/download/0.2.4/cheadergen_cli-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/LukeMathWalker/cheadergen/releases/download/0.3.0/cheadergen_cli-installer.ps1 | iex"
 ```
 
 Installers download prebuilt binaries from our [GitHub releases](https://github.com/LukeMathWalker/cheadergen/releases/latest). Each archive ships with a sibling `.sha256` file you can use to verify the

--- a/ui-tests/cbindgen/tests/cbindgen/rust/cases/Cargo.lock
+++ b/ui-tests/cbindgen/tests/cbindgen/rust/cases/Cargo.lock
@@ -135,14 +135,14 @@ version = "0.1.0"
 
 [[package]]
 name = "cheadergen"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "cheadergen_macros",
 ]
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ui-tests/cheadergen/tests/cheadergen/rust/cases/Cargo.lock
+++ b/ui-tests/cheadergen/tests/cheadergen/rust/cases/Cargo.lock
@@ -56,14 +56,14 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "cheadergen_macros",
 ]
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## 🤖 New release

* `cheadergen_macros`: 0.2.4 -> 0.3.0
* `cheadergen`: 0.2.4 -> 0.3.0
* `cheadergen_cli`: 0.2.4 -> 0.3.0
