### PR TITLE
chore: Sync test workspace lockfiles to v0.3.1

### DIFF
--- a/ui-tests/cbindgen/tests/cbindgen/rust/cases/Cargo.lock
+++ b/ui-tests/cbindgen/tests/cbindgen/rust/cases/Cargo.lock
@@ -135,14 +135,14 @@ version = "0.1.0"
 
 [[package]]
 name = "cheadergen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cheadergen_macros",
 ]
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ui-tests/cheadergen/tests/cheadergen/rust/cases/Cargo.lock
+++ b/ui-tests/cheadergen/tests/cheadergen/rust/cases/Cargo.lock
@@ -56,14 +56,14 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cheadergen_macros",
 ]
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
The `cheadergen` and `cheadergen_macros` path dependencies were bumped to 0.3.1 in the last release, but the ui-test workspace lockfiles were not regenerated. Any test run rewrites them, leaving the working tree dirty.

First of three PRs improving `source_order` determinism: this one, then #30, then #31 (the main fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)