### PR TITLE
fix: Break source-order ties for extern items by name

### DIFF
--- a/cheadergen_cli/src/analysis/mod.rs
+++ b/cheadergen_cli/src/analysis/mod.rs
@@ -44,7 +44,7 @@ pub fn sort_local_ids_by_key(ids: &mut [rustdoc_types::Id], sort_by: SortKey, kr
     match sort_by {
         SortKey::SourceOrder => ids.sort_by_cached_key(|id| {
             let (line, col) = span_sort_key_local(id, krate);
-            (line, col, String::new())
+            (line, col, name_sort_key_local(id, krate))
         }),
         SortKey::Name => ids.sort_by_cached_key(|id| name_sort_key_local(id, krate)),
     }

--- a/ui-tests/cbindgen/tests/cbindgen/rust/cases/Cargo.lock
+++ b/ui-tests/cbindgen/tests/cbindgen/rust/cases/Cargo.lock
@@ -135,14 +135,14 @@ version = "0.1.0"
 
 [[package]]
 name = "cheadergen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cheadergen_macros",
 ]
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ui-tests/cheadergen/tests/cheadergen/rust/cases/Cargo.lock
+++ b/ui-tests/cheadergen/tests/cheadergen/rust/cases/Cargo.lock
@@ -56,14 +56,14 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cheadergen_macros",
 ]
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
The extern item sort (functions, statics, constants) uses an empty string as the final tie-break component, so items sharing a span position — in practice items without a span, which all collide at `(usize::MAX, usize::MAX)` — fall back to unstable rustdoc ID order. This PR uses the item name instead, matching what the type-definition sort already does via `fallback_name()`.

No snapshot changes: the existing test suite has no span-less extern items, so behavior is preserved everywhere it was already deterministic.

Stacked on #29 (its commit shows in this diff until it merges). Part of a series improving `source_order` determinism; the main fix follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)