### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/LukeMathWalker/cheadergen/compare/0.3.1...0.3.2) - 2026-08-12
+
+### 🐛 Bug Fixes
+
+- Make type definitions honor sort_by (by @memark) - #32
+- Group items by source file when sorting in source order (by @memark) - #31
+- Break source-order ties for extern items by name (by @memark) - #30
+
+### Contributors
+
+- @memark
+
 ## [0.3.1](https://github.com/LukeMathWalker/cheadergen/compare/0.3.0...0.3.1) - 2026-06-21
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cheadergen_macros",
  "trybuild",
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cheadergen_macros"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 homepage = "https://cheadergen.com"
 repository = "https://github.com/LukeMathWalker/cheadergen"
 license = "Apache-2.0"
-version = "0.3.1"
+version = "0.3.2"
 
 [workspace.lints.clippy]
 # Use `#[expect]` instead of `#[allow]` so we are warned when they become obsolete.
@@ -19,9 +19,9 @@ allow_attributes = "warn"
 private-intra-doc-links = "allow"
 
 [workspace.dependencies]
-cheadergen = { path = "cheadergen", version = "0.3.1" }
-cheadergen_cli = { path = "cheadergen_cli", version = "0.3.1" }
-cheadergen_macros = { path = "cheadergen_macros", version = "0.3.1" }
+cheadergen = { path = "cheadergen", version = "0.3.2" }
+cheadergen_cli = { path = "cheadergen_cli", version = "0.3.2" }
+cheadergen_macros = { path = "cheadergen_macros", version = "0.3.2" }
 rustdoc-types = "0.57.3"
 rustdoc_ext = "0.1.1"
 rustdoc_ir = "0.1.1"

--- a/docs/src/getting-started/install.md
+++ b/docs/src/getting-started/install.md
@@ -12,7 +12,7 @@ On macOS or Linux:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/LukeMathWalker/cheadergen/releases/download/0.3.1/cheadergen_cli-installer.sh \
+  https://github.com/LukeMathWalker/cheadergen/releases/download/0.3.2/cheadergen_cli-installer.sh \
   | sh
 ```
 
@@ -22,7 +22,7 @@ The installer downloads the prebuilt binary for your platform and drops it into
 On Windows, via Powershell:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/LukeMathWalker/cheadergen/releases/download/0.3.1/cheadergen_cli-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/LukeMathWalker/cheadergen/releases/download/0.3.2/cheadergen_cli-installer.ps1 | iex"
 ```
 
 Installers download prebuilt binaries from our [GitHub releases](https://github.com/LukeMathWalker/cheadergen/releases/latest). Each archive ships with a sibling `.sha256` file you can use to verify the


### PR DESCRIPTION



## 🤖 New release

* `cheadergen_macros`: 0.3.1 -> 0.3.2
* `cheadergen`: 0.3.1 -> 0.3.2
* `cheadergen_cli`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `cheadergen`

<blockquote>

## [0.3.2](https://github.com/LukeMathWalker/cheadergen/compare/0.3.1...0.3.2) - 2026-08-12

### 🐛 Bug Fixes

- Make type definitions honor sort_by (by @memark) - #32
- Group items by source file when sorting in source order (by @memark) - #31
- Break source-order ties for extern items by name (by @memark) - #30

### Contributors

- @memark
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).